### PR TITLE
create our own container for building the doc

### DIFF
--- a/tools/gendoc/doc-container/.dockerignore
+++ b/tools/gendoc/doc-container/.dockerignore
@@ -1,0 +1,3 @@
+tmp*
+*.tmp
+README.*

--- a/tools/gendoc/doc-container/Dockerfile
+++ b/tools/gendoc/doc-container/Dockerfile
@@ -1,0 +1,3 @@
+FROM	rsyslog/rsyslog_doc_gen
+LABEL	maintainer rgerhards@adiscon.com
+RUN	pip install sphinx-better-theme

--- a/tools/gendoc/doc-container/README.md
+++ b/tools/gendoc/doc-container/README.md
@@ -1,0 +1,3 @@
+Container to build doc for rsyslog.com.
+
+Extends the rsyslog doc gen container (rsyslog/rsyslog_doc_gen).

--- a/tools/gendoc/gendoc.sh
+++ b/tools/gendoc/gendoc.sh
@@ -20,7 +20,7 @@ if [ "$SERVER_UPDATE_CMD" == "" ]; then
 	exit 1
 fi
 echo "======starting doc generation======="
-docker pull rsyslog/rsyslog_doc_gen # get fresh version
+docker pull rsyslog/rsyslog_doc_gen_website # get fresh version
 cd $DOC_HOME
 
 for branch in v5-stable v7-stable v8-stable master;
@@ -36,6 +36,6 @@ do
 		-v "$DOC_HOME":/rsyslog-doc \
 		-v "$WEB_PRJ_HOME/tools/gendoc/SPHINX_EXTRA_OPTS:/rsyslog-doc/SPHINX_EXTRA_OPTS" \
 		-e STRICT="" \
-		rsyslog/rsyslog_doc_gen
+		rsyslog/rsyslog_doc_gen_website
 	$SERVER_UPDATE_CMD $branch
 done


### PR DESCRIPTION
Previously, the standard doc container provided some site-exclusive
specials. This was mixing feature domains and caused quite a bit
of confusion. Thus, the standard container was cleaned up. We now
add our own container def on top of it and use it during doc building.

see also https://github.com/rsyslog/rsyslog-doc/pull/553
see also https://github.com/rsyslog/rsyslog-doc/pull/543#issuecomment-364761077